### PR TITLE
[codex] Derive sitemap lastmod from Git history

### DIFF
--- a/build.py
+++ b/build.py
@@ -85,6 +85,14 @@ class BuildStats:
         return self.failed > 0
 
 
+@dataclass(frozen=True)
+class GitLastModified:
+    """A tracked file's most recent Git commit time and calendar date."""
+
+    timestamp: int
+    date: str
+
+
 class HTMLMetadataParser(HTMLParser):
     """
     从 HTML 文件中提取元数据的解析器。
@@ -1246,6 +1254,92 @@ def generate_rss(site_url: str) -> bool:
         return False
 
 
+def get_git_last_modified(path: Path) -> GitLastModified:
+    """Return the latest commit time for one tracked file, following renames."""
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            "-1",
+            "--follow",
+            "--format=%ct%x00%cs",
+            "--",
+            path.as_posix(),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"git log exited with {result.returncode}"
+        raise RuntimeError(f"无法读取 {path} 的 Git 历史: {detail}")
+
+    output = result.stdout.strip()
+    if not output:
+        raise RuntimeError(f"Git 历史中没有源文件: {path}")
+
+    try:
+        timestamp_text, commit_date = output.split("\x00", maxsplit=1)
+        return GitLastModified(timestamp=int(timestamp_text), date=commit_date)
+    except (TypeError, ValueError) as e:
+        raise RuntimeError(f"无法解析 {path} 的 Git 修改时间: {output!r}") from e
+
+
+def find_blog_post_sources() -> list[Path]:
+    """Return actual blog post sources, excluding the index and helper files."""
+    blog_dir = CONTENT_DIR / "Blog"
+    if not blog_dir.exists():
+        return []
+
+    post_sources = []
+    for typ_file in sorted(blog_dir.rglob("*.typ")):
+        rel_path = typ_file.relative_to(blog_dir)
+        if rel_path == Path("index.typ") or "pdf" in typ_file.stem.lower():
+            continue
+        if any(part.startswith("_") for part in rel_path.parts):
+            continue
+        post_sources.append(typ_file)
+    return post_sources
+
+
+def find_latest_blog_post_source() -> tuple[Path, datetime]:
+    """Find the latest blog post using the same published date as the archive."""
+    dated_posts: list[tuple[datetime, Path]] = []
+    for source_path in find_blog_post_sources():
+        html_path = SITE_DIR / source_path.relative_to(CONTENT_DIR).with_suffix(".html")
+        if not html_path.exists():
+            raise RuntimeError(f"博客文章缺少已生成的 HTML: {html_path}")
+        _, _, _, published_at = extract_post_metadata(html_path)
+        if published_at is not None:
+            dated_posts.append((published_at, source_path))
+
+    if not dated_posts:
+        raise RuntimeError("Blog/index.html 没有带发布日期的博客文章")
+
+    published_at, source_path = max(dated_posts, key=lambda item: item[0])
+    return source_path, published_at
+
+
+def get_sitemap_lastmod(
+    html_path: Path,
+    git_dates: dict[Path, GitLastModified],
+) -> tuple[str, Path]:
+    """Resolve an HTML page's sitemap date from its source file's Git history."""
+    rel_path = html_path.relative_to(SITE_DIR)
+
+    def cached_git_date(source_path: Path) -> GitLastModified:
+        if source_path not in git_dates:
+            git_dates[source_path] = get_git_last_modified(source_path)
+        return git_dates[source_path]
+
+    if rel_path == Path("Blog/index.html"):
+        latest_source, _ = find_latest_blog_post_source()
+        return cached_git_date(latest_source).date, latest_source
+
+    source_path = CONTENT_DIR / rel_path.with_suffix(".typ")
+    return cached_git_date(source_path).date, source_path
+
+
 def generate_sitemap(site_url: str) -> bool:
     """
     使用 Python 标准库 xml.etree.ElementTree 生成 sitemap.xml。
@@ -1261,30 +1355,61 @@ def generate_sitemap(site_url: str) -> bool:
     # 创建根元素
     urlset = ET.Element("urlset", xmlns=sitemap_ns)
 
-    # 遍历 _site 目录
-    for file_path in sorted(SITE_DIR.rglob("*.html")):
-        rel_path = file_path.relative_to(SITE_DIR).as_posix()
+    shallow_result = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if shallow_result.returncode != 0:
+        print("❌ Sitemap 构建失败: 当前目录不是可读取历史的 Git 仓库")
+        return False
+    if shallow_result.stdout.strip() == "true":
+        print("❌ Sitemap 构建失败: Git 仓库是浅克隆，请先运行 git fetch --unshallow")
+        return False
 
-        # 确定 URL 路径
-        if rel_path == "index.html":
-            url_path = ""
-        elif rel_path.endswith("/index.html"):
-            url_path = rel_path.removesuffix("index.html")
-        elif rel_path.endswith(".html"):
-            url_path = rel_path.removesuffix(".html") + "/"
-        else:
-            url_path = rel_path
+    print("ℹ️ Sitemap lastmod 使用对应 .typ 文件的 Git 最后提交日期")
+    git_dates: dict[Path, GitLastModified] = {}
+    blog_index_source: Path | None = None
+    blog_index_lastmod: str | None = None
 
-        full_url = f"{site_url}/{url_path}"
+    try:
+        # 遍历 _site 目录
+        for file_path in sorted(SITE_DIR.rglob("*.html")):
+            rel_path = file_path.relative_to(SITE_DIR).as_posix()
 
-        # 获取最后修改时间
-        mtime = file_path.stat().st_mtime
-        lastmod = datetime.fromtimestamp(mtime).strftime("%Y-%m-%d")
+            # 确定 URL 路径
+            if rel_path == "index.html":
+                url_path = ""
+            elif rel_path.endswith("/index.html"):
+                url_path = rel_path.removesuffix("index.html")
+            elif rel_path.endswith(".html"):
+                url_path = rel_path.removesuffix(".html") + "/"
+            else:
+                url_path = rel_path
 
-        # 创建 url 元素
-        url_elem = ET.SubElement(urlset, "url")
-        ET.SubElement(url_elem, "loc").text = full_url
-        ET.SubElement(url_elem, "lastmod").text = lastmod
+            full_url = f"{site_url}/{url_path}"
+
+            # 从对应 Typst 源文件的 Git 历史获取最后修改日期。
+            lastmod, source_path = get_sitemap_lastmod(file_path, git_dates)
+            if rel_path == "Blog/index.html":
+                blog_index_source = source_path
+                blog_index_lastmod = lastmod
+
+            # 创建 url 元素
+            url_elem = ET.SubElement(urlset, "url")
+            ET.SubElement(url_elem, "loc").text = full_url
+            ET.SubElement(url_elem, "lastmod").text = lastmod
+    except RuntimeError as e:
+        print(f"❌ Sitemap 构建失败: {e}")
+        return False
+
+    if blog_index_source is not None:
+        print(
+            "ℹ️ Blog/index.html lastmod: "
+            f"{blog_index_lastmod}（按发布日期选择最新文章 "
+            f"{blog_index_source.as_posix()}）"
+        )
 
     # 生成 XML 字符串
     ET.indent(urlset, space="  ")

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+git_history_state="$(git rev-parse --is-shallow-repository)"
+echo "Sitemap Git history: shallow=${git_history_state}"
+if [[ "${git_history_state}" == "true" ]]; then
+    echo "Fetching complete Git history for sitemap lastmod dates..."
+    git fetch --unshallow --no-tags origin
+    echo "Sitemap Git history: shallow=$(git rev-parse --is-shallow-repository)"
+fi
+
 curl -s -L https://github.com/typst/typst/releases/download/v0.15.1/typst-x86_64-unknown-linux-musl.tar.xz | tar -Jxvf - -C ./
 npm ci
 export PATH="$(pwd)/typst-x86_64-unknown-linux-musl:$PATH"

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,111 @@
+import subprocess
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import patch
+
+import build
+
+
+class SitemapLastmodTests(unittest.TestCase):
+    def test_get_git_last_modified_parses_timestamp_and_date(self):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="1756081817\x002025-08-25\n", stderr=""
+        )
+
+        with patch.object(build.subprocess, "run", return_value=completed):
+            modified = build.get_git_last_modified(Path("content/page.typ"))
+
+        self.assertEqual(modified, build.GitLastModified(1756081817, "2025-08-25"))
+
+    def test_blog_index_uses_git_date_of_latest_published_article(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            content_dir = root / "content"
+            site_dir = root / "_site"
+            old_post = content_dir / "Blog/2024/old/index.typ"
+            new_post = content_dir / "Blog/2025/new/index.typ"
+            old_post_html = site_dir / "Blog/2024/old/index.html"
+            new_post_html = site_dir / "Blog/2025/new/index.html"
+            blog_index = content_dir / "Blog/index.typ"
+            ignored_helper = content_dir / "Blog/_posts.typ"
+            for path in (old_post, new_post, blog_index, ignored_helper):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+            old_post_html.parent.mkdir(parents=True, exist_ok=True)
+            old_post_html.write_text(
+                '<meta name="date" content="2024-01-02">', encoding="utf-8"
+            )
+            new_post_html.parent.mkdir(parents=True, exist_ok=True)
+            new_post_html.write_text(
+                '<meta name="date" content="2025-03-04">', encoding="utf-8"
+            )
+
+            dates = {
+                # Commit order deliberately disagrees with publication order.
+                old_post: build.GitLastModified(200, "2025-05-06"),
+                new_post: build.GitLastModified(100, "2025-03-05"),
+            }
+
+            with (
+                patch.object(build, "CONTENT_DIR", content_dir),
+                patch.object(build, "SITE_DIR", site_dir),
+                patch.object(build, "get_git_last_modified", side_effect=dates.__getitem__),
+            ):
+                lastmod, source = build.get_sitemap_lastmod(
+                    site_dir / "Blog/index.html", {}
+                )
+
+        self.assertEqual(lastmod, "2025-03-05")
+        self.assertEqual(source, new_post)
+
+    def test_generate_sitemap_uses_source_commit_dates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            content_dir = root / "content"
+            site_dir = root / "_site"
+            home_html = site_dir / "index.html"
+            blog_html = site_dir / "Blog/index.html"
+            post_source = content_dir / "Blog/2025/post/index.typ"
+            for path in (home_html, blog_html, post_source):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+
+            git_check = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="false\n", stderr=""
+            )
+
+            def sitemap_date(html_path, _git_dates):
+                if html_path == blog_html:
+                    return "2025-06-07", post_source
+                return "2024-02-03", content_dir / "index.typ"
+
+            with (
+                patch.object(build, "CONTENT_DIR", content_dir),
+                patch.object(build, "SITE_DIR", site_dir),
+                patch.object(build.subprocess, "run", return_value=git_check),
+                patch.object(build, "get_sitemap_lastmod", side_effect=sitemap_date),
+            ):
+                self.assertTrue(build.generate_sitemap("https://example.com"))
+
+            root_element = ET.parse(site_dir / "sitemap.xml").getroot()
+            namespace = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+            entries = {
+                entry.findtext("s:loc", namespaces=namespace): entry.findtext(
+                    "s:lastmod", namespaces=namespace
+                )
+                for entry in root_element.findall("s:url", namespace)
+            }
+
+        self.assertEqual(
+            entries,
+            {
+                "https://example.com/": "2024-02-03",
+                "https://example.com/Blog/": "2025-06-07",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- derive each sitemap `lastmod` from the corresponding tracked `.typ` file's latest Git commit
- select the `/Blog/` source from the latest article by publication date
- expand shallow Git history in the Cloudflare `build.sh` path and print diagnostics in the build log
- add focused sitemap unit tests

## Why

Forced Cloudflare builds rewrite every generated HTML file, so filesystem mtimes make every page appear modified at deployment time. Git history provides reproducible source modification dates across builds.

## Impact

Sitemap dates now remain stable across clean cloud builds. A shallow checkout is expanded before the build; sitemap generation fails clearly if full Git history is unavailable instead of silently emitting deployment dates.

## Validation

- `python -m unittest discover -s tests -v`
- `python -m py_compile build.py tests/test_sitemap.py`
- `bash -n build.sh`
- `git diff --check`
- `python build.py build -f` (29 HTML pages, 25 RSS posts)